### PR TITLE
Update colophon.xhtml

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -12,7 +12,7 @@
 				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">South!</i><br/>
-			was published in 1920 by<br/>
+			was published in 1919 by<br/>
 			<a href="https://en.wikipedia.org/wiki/Ernest_Shackleton">Ernest Shackleton</a>.</p>
 			<p>This ebook was produced for<br/>
 			<a href="https://standardebooks.org">Standard Ebooks</a><br/>


### PR DESCRIPTION
**Changed the publication date from 1920 to 1919.**

South! (Ernest Shackleton) was first published in November 1919.

**Sources:**
- Internet Archive:  https://archive.org/details/South00Shac/page/n13/mode/2up?view=theater
- WorldCat:  https://search.worldcat.org/title/13627467